### PR TITLE
Skip to the next song when the current is finished playing - Relates #6

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,3 +147,6 @@ audioElement.addEventListener('timeupdate', updateProgress);
 
 // Add event listener to make progress bar clickable
 progressContainer.addEventListener('click', setProgress);
+
+// Add event listener to audio element to skip to next song when previous is ended, by calling nextSong()
+  audioElement.addEventListener('ended', nextSong);


### PR DESCRIPTION
Added event listener to the audio element; it will listen to the 'ended'
event and call nextSong() when the currently playing song has ended.